### PR TITLE
Optimized gamecenteravailability

### DIFF
--- a/GC Manager/GameCenterManager.h
+++ b/GC Manager/GameCenterManager.h
@@ -63,6 +63,20 @@ enum {
 /// GameCenterManager error codes that may be passed in a completion handler's error parameter
 typedef NSInteger GCMErrorCode;
 
+/// GameCenter availability status. Use these statuss to identify the state of GameCenter's availability.
+typedef enum GameCenterAvailability {
+	/// GameKit Framework not available on this device
+	GameCenterAvailabilityNotAvailable,
+	/// Cannot connect to the internet
+	GameCenterAvailabilityNoInternet,
+	/// Player is not yet signed into GameCenter
+	GameCenterAvailabilityNoPlayer,
+	/// Player is not signed into GameCenter, has declined to sign into GameCenter, or GameKit had an issue validating this game / app
+	GameCenterAvailabilityPlayerNotAuthenticated,
+	/// Player is signed into GameCenter
+	GameCenterAvailabilityPlayerAuthenticated
+} GameCenterAvailability;
+
 
 
 
@@ -208,8 +222,11 @@ typedef NSInteger GCMErrorCode;
 /// Returns YES if an active internet connection is available.
 - (BOOL)isInternetAvailable;
 
+/// DEPRECATED. Use checkGameCenterAvailability: ignorePreviousStatus: instead.
+- (BOOL)checkGameCenterAvailability __deprecated;
+
 /// Check if Game Center is supported
-- (BOOL)checkGameCenterAvailability;
+- (BOOL)checkGameCenterAvailability:(BOOL)ignorePreviousStatus;
 
 /// Use this property to check if Game Center is available and supported on the current device.
 @property (nonatomic, assign) BOOL isGameCenterAvailable;

--- a/GC Manager/GameCenterManager.m
+++ b/GC Manager/GameCenterManager.m
@@ -23,6 +23,7 @@
 @property (nonatomic, assign, readwrite) BOOL shouldCryptData;
 @property (nonatomic, strong, readwrite) NSString *cryptKey;
 @property (nonatomic, strong, readwrite) NSData *cryptKeyData;
+@property (nonatomic, assign, readwrite) GameCenterAvailability previousGameCenterAvailability;
 
 @end
 
@@ -43,7 +44,7 @@
 - (id)init {
     self = [super init];
     if (self) {
-        BOOL gameCenterAvailable = [self checkGameCenterAvailability];
+        BOOL gameCenterAvailable = [self checkGameCenterAvailability:YES];
         
         if (gameCenterAvailable) {
             // Set GameCenter as available
@@ -119,6 +120,12 @@
 }
 
 - (BOOL)checkGameCenterAvailability {
+    // left here for backwards compatibility. Because previous versions of GameCenterManager were built with without the ignorePreviousState feature, we will preserve the old
+    NSLog(@"WARNING: Calling a deprecated GameCenterManager method that may become obsolete in future versions. Use checkGameCenterAvailability: ignorePreviousStatus: instead. %s", __PRETTY_FUNCTION__);
+    return [self checkGameCenterAvailability:YES];
+}
+
+- (BOOL)checkGameCenterAvailability:(BOOL)ignorePreviousStatus {
 #if TARGET_OS_IPHONE
     // First, check if the the GameKit Framework exists on the device. Return NO if it does not.
     BOOL localPlayerClassAvailable = (NSClassFromString(@"GKLocalPlayer")) != nil;
@@ -131,12 +138,15 @@
 #endif
     
     if (!isGameCenterAPIAvailable) {
-        NSDictionary *errorDictionary = @{@"message": @"GameKit Framework not available on this device. GameKit is only available on devices with iOS 4.1 or higher. Some devices running iOS 4.1 may not have GameCenter enabled.", @"title": @"GameCenter Unavailable"};
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
-                [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
-        });
+        if ([self previousGameCenterAvailability] != GameCenterAvailabilityNotAvailable) {
+            [self setPreviousGameCenterAvailability:GameCenterAvailabilityNotAvailable];
+            NSDictionary *errorDictionary = @{@"message": @"GameKit Framework not available on this device. GameKit is only available on devices with iOS 4.1 or     higher. Some devices running iOS 4.1 may not have GameCenter enabled.", @"title": @"GameCenter Unavailable"};
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
+                    [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
+            });
+        }
         
         return NO;
         
@@ -144,12 +154,15 @@
         // The GameKit Framework is available. Now check if an internet connection can be established
         BOOL internetAvailable = [self isInternetAvailable];
         if (!internetAvailable) {
-            NSDictionary *errorDictionary = @{@"message": @"Cannot connect to the internet. Connect to the internet to establish a connection with GameCenter. Achievements and scores will still be saved locally and then uploaded later.", @"title": @"Internet Unavailable"};
+            if ([self previousGameCenterAvailability] != GameCenterAvailabilityNoInternet) {
+                [self setPreviousGameCenterAvailability:GameCenterAvailabilityNoInternet];
+                NSDictionary *errorDictionary = @{@"message": @"Cannot connect to the internet. Connect to the internet to establish a connection with GameCenter. Achievements and scores will still be saved locally and then uploaded later.", @"title": @"Internet Unavailable"};
             
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
-                    [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
-            });
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
+                        [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
+                });
+            }
             
             return NO;
             
@@ -159,62 +172,74 @@
 #if TARGET_OS_IPHONE
             localPlayer.authenticateHandler = ^(UIViewController *viewController, NSError *error) {
                 if (viewController != nil) {
-                    NSDictionary *errorDictionary = @{@"message": @"Player is not yet signed into GameCenter. Please prompt the player using the authenticateUser delegate method.", @"title": @"No Player"};
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
-                            [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
+                    if ([self previousGameCenterAvailability] != GameCenterAvailabilityNoPlayer) {
+                        [self setPreviousGameCenterAvailability:GameCenterAvailabilityNoPlayer];
+                        NSDictionary *errorDictionary = @{@"message": @"Player is not yet signed into GameCenter. Please prompt the player using the authenticateUser delegate method.", @"title": @"No Player"};
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
+                                [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
                         
-                        if ([[self delegate] respondsToSelector:@selector(gameCenterManager:authenticateUser:)]) {
-                            [[self delegate] gameCenterManager:self authenticateUser:viewController];
-                        } else {
-                            NSLog(@"[ERROR] %@ Fails to Respond to the required delegate method gameCenterManager:authenticateUser:. This delegate method must be properly implemented to use GC Manager", [self delegate]);
-                        }
-                    });
+                            if ([[self delegate] respondsToSelector:@selector(gameCenterManager:authenticateUser:)]) {
+                                [[self delegate] gameCenterManager:self authenticateUser:viewController];
+                            } else {
+                                NSLog(@"[ERROR] %@ Fails to Respond to the required delegate method gameCenterManager:authenticateUser:. This delegate method must be properly implemented to use GC Manager", [self delegate]);
+                            }
+                        });
+                    }
                 } else if (!error) {
                     // Authentication handler completed successfully. Re-check availability
-                    [self checkGameCenterAvailability];
+                    [self checkGameCenterAvailability:ignorePreviousStatus];
                 }
             };
 #else
             localPlayer.authenticateHandler = ^(NSViewController *viewController, NSError *error) {
                 if (viewController != nil) {
-                    NSDictionary *errorDictionary = @{@"message": @"Player is not yet signed into GameCenter. Please prompt the player using the authenticateUser delegate method.", @"title": @"No Player"};
+                    if ([self previousGameCenterAvailability] != GameCenterAvailabilityNoPlayer) {
+                        [self setPreviousGameCenterAvailability:GameCenterAvailabilityNoPlayer];
+                        NSDictionary *errorDictionary = @{@"message": @"Player is not yet signed into GameCenter. Please prompt the player using the authenticateUser delegate method.", @"title": @"No Player"};
                     
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
-                            [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
-                        
-                        if ([[self delegate] respondsToSelector:@selector(gameCenterManager:authenticateUser:)]) {
-                            [[self delegate] gameCenterManager:self authenticateUser:viewController];
-                        } else {
-                            NSLog(@"[ERROR] %@ Fails to Respond to the required delegate method gameCenterManager:authenticateUser:. This delegate method must be properly implemented to use GC Manager", [self delegate]);
-                        }
-                    });
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
+                                [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
+                            
+                            if ([[self delegate] respondsToSelector:@selector(gameCenterManager:authenticateUser:)]) {
+                                [[self delegate] gameCenterManager:self authenticateUser:viewController];
+                            } else {
+                                NSLog(@"[ERROR] %@ Fails to Respond to the required delegate method gameCenterManager:authenticateUser:. This delegate method must be properly implemented to use GC Manager", [self delegate]);
+                            }
+                        });
+                    }
                 } else if (!error) {
                     // Authentication handler completed successfully. Re-check availability
-                    [self checkGameCenterAvailability];
+                    [self checkGameCenterAvailability:ignorePreviousStatus];
                 }
             };
 #endif
             
             if (![[GKLocalPlayer localPlayer] isAuthenticated]) {
-                NSDictionary *errorDictionary = @{@"message": @"Player is not signed into GameCenter, has declined to sign into GameCenter, or GameKit had an issue validating this game / app.", @"title": @"Player not Authenticated"};
+                if ([self previousGameCenterAvailability] != GameCenterAvailabilityPlayerNotAuthenticated) {
+                    [self setPreviousGameCenterAvailability:GameCenterAvailabilityPlayerNotAuthenticated];
+                    NSDictionary *errorDictionary = @{@"message": @"Player is not signed into GameCenter, has declined to sign into GameCenter, or GameKit had an issue validating this game / app.", @"title": @"Player not Authenticated"};
                 
-                if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
-                    [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
+                    if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
+                        [[self delegate] gameCenterManager:self availabilityChanged:errorDictionary];
+                }
                 
                 return NO;
                 
             } else {
-                // The current player is logged into GameCenter
-                NSDictionary *successDictionary = [NSDictionary dictionaryWithObject:@"GameCenter Available" forKey:@"status"];
+                if ([self previousGameCenterAvailability] != GameCenterAvailabilityPlayerAuthenticated) {
+                    [self setPreviousGameCenterAvailability:GameCenterAvailabilityPlayerAuthenticated];
+                    // The current player is logged into GameCenter
+                    NSDictionary *successDictionary = [NSDictionary dictionaryWithObject:@"GameCenter Available" forKey:@"status"];
+                    
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
+                            [[self delegate] gameCenterManager:self availabilityChanged:successDictionary];
+                    });
                 
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
-                        [[self delegate] gameCenterManager:self availabilityChanged:successDictionary];
-                });
-                
-                self.isGameCenterAvailable = YES;
+                    self.isGameCenterAvailable = YES;
+                }
                 
                 return YES;
             }
@@ -263,7 +288,7 @@
     dispatch_async(syncGameCenterOnBackgroundThread, ^{
         
         // Check if GameCenter is available
-        if ([self checkGameCenterAvailability] == YES) {
+        if ([self checkGameCenterAvailability:NO] == YES) {
             // Check if Leaderboard Scores are synced
             if (![[NSUserDefaults standardUserDefaults] boolForKey:[@"scoresSynced" stringByAppendingString:[self localPlayerId]]]) {
                 if (GCMLeaderboards == nil) {
@@ -387,7 +412,7 @@
     backgroundProcess = UIBackgroundTaskInvalid;
 #else
     // Check if GameCenter is available
-    if ([self checkGameCenterAvailability] == YES) {
+    if ([self checkGameCenterAvailability:NO] == YES) {
         // Check if Leaderboard Scores are synced
         if (![[NSUserDefaults standardUserDefaults] boolForKey:[@"scoresSynced" stringByAppendingString:[self localPlayerId]]]) {
             if (GCMLeaderboards == nil) {
@@ -621,7 +646,7 @@
         [saveData writeToFile:kGameCenterManagerDataPath atomically:YES];
     }
     
-    if ([self checkGameCenterAvailability] == YES) {
+    if ([self checkGameCenterAvailability:NO] == YES) {
 #if TARGET_OS_IPHONE
         GKScore *gkScore = [[GKScore alloc] initWithLeaderboardIdentifier:identifier];
 #else
@@ -683,7 +708,7 @@
         [saveData writeToFile:kGameCenterManagerDataPath atomically:YES];
     }
     
-    if ([self checkGameCenterAvailability] == YES) {
+    if ([self checkGameCenterAvailability:NO] == YES) {
         GKAchievement *achievement = [[GKAchievement alloc] initWithIdentifier:identifier];
         achievement.percentComplete = percentComplete;
         if (displayNotification == YES) achievement.showsCompletionBanner = YES;
@@ -905,7 +930,7 @@
 }
 
 - (void)getChallengesWithCompletion:(void (^)(NSArray *challenges, NSError *error))handler {
-    if ([self checkGameCenterAvailability] == YES) {
+    if ([self checkGameCenterAvailability:NO] == YES) {
         BOOL isGameCenterChallengeAPIAvailable = (NSClassFromString(@"GKChallenge")) != nil;
         
         if (isGameCenterChallengeAPIAvailable == YES) {

--- a/GameCenterManager Mac/MacViewController.m
+++ b/GameCenterManager Mac/MacViewController.m
@@ -31,7 +31,7 @@
         [[GameCenterManager sharedManager] setDelegate:self];
         
         // Setup Game Center Manager
-        BOOL available = [[GameCenterManager sharedManager] checkGameCenterAvailability];
+        BOOL available = [[GameCenterManager sharedManager] checkGameCenterAvailability:YES];
         if (available) self.gameCenterStatus.stringValue = @"GAME CENTER AVAILABLE";
         else self.gameCenterStatus.stringValue = @"GAME CENTER UNAVAILABLE";
         

--- a/GameCenterManager/ViewController.m
+++ b/GameCenterManager/ViewController.m
@@ -34,7 +34,7 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:YES];
 
-    BOOL available = [[GameCenterManager sharedManager] checkGameCenterAvailability];
+    BOOL available = [[GameCenterManager sharedManager] checkGameCenterAvailability:YES];
     if (available) {
         [self.navigationController.navigationBar setValue:@"GameCenter Available" forKeyPath:@"prompt"];
     } else {

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ These methods are not interchangable. If you decide to setup with encryption the
 ###Check Game Center Support
 GameCenter Manager automatically checks if Game Center is available before performing any Game Center-related operations. You can also check for Game Center availability by using the following method, which returns a `BOOL` value (YES / NO).
 
-    BOOL isAvailable = [[GameCenterManager sharedManager] checkGameCenterAvailability];
+    // Will not call delegate if status has not changed from the previous time it was called
+    BOOL isAvailable = [[GameCenterManager sharedManager] checkGameCenterAvailability:NO];
+
+    // Will always call delegate even if status has not changed from the previous time it was called
+    BOOL isAvailable = [[GameCenterManager sharedManager] checkGameCenterAvailability:YES];
 
 This method will perform the following checks in the following order:
  1. Current OS version new enough to run Game Center. iOS 4.1 or OS X 10.8. Some Game Center methods require newer OS versions which will be checked (ex. challenges and some multiplayer features).


### PR DESCRIPTION
Added ability not to call the delegates for checkGameCenterAvailability: if the status has not truely changed by passing `NO`. This can be ignored by passing `YES`. The old functionality was left for backwards compatibility Fell free to make changes or let me know how I can change it if I missed something.

Fixes #38 