### PR TITLE
Fix int maximum issue for scores with long long integer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+GameCenterManager.xcodeproj/project.xcworkspace/xcuserdata
+GameCenterManager.xcodeproj/xcuserdata

--- a/GC Manager/GameCenterManager.h
+++ b/GC Manager/GameCenterManager.h
@@ -105,10 +105,10 @@ typedef NSInteger GCMErrorCode;
 
 /** Saves score locally and reports it to Game Center. If error occurs, score is saved to be submitted later. 
  
- @param score The int value of the score to be submitted to Game Center. This score should not be formatted, instead it should be a plain int. For example, if you wanted to submit a score of 45.28 meters then you would submit it as an integer of 4528. To format your scores, you must set the Score Formatter for your leaderboard in iTunes Connect.
+ @param score The long long value of the score to be submitted to Game Center. This score should not be formatted, instead it should be a plain long long (int). For example, if you wanted to submit a score of 45.28 meters then you would submit it as an integer of 4528. To format your scores, you must set the Score Formatter for your leaderboard in iTunes Connect.
  @param identifier The Leaderboard ID set through iTunes Connect. This is different from the name of the leaderboard, and it is not shown to the user. 
  @param order The score sort order that you set in iTunes Connect - either high to low or low to high. This is used to determine if the user has a new highscore before submitting. */
-- (void)saveAndReportScore:(int)score leaderboard:(NSString *)identifier sortOrder:(GameCenterSortOrder)order __attribute__((nonnull));
+- (void)saveAndReportScore:(long long)score leaderboard:(NSString *)identifier sortOrder:(GameCenterSortOrder)order __attribute__((nonnull));
 
 /** Saves achievement locally and reports it to Game Center. If error occurs, achievement is saved to be submitted later.
  
@@ -133,7 +133,7 @@ typedef NSInteger GCMErrorCode;
 
 
 /// Returns local player's high score for specified leaderboard.
-- (int)highScoreForLeaderboard:(NSString *)identifier;
+- (long long)highScoreForLeaderboard:(NSString *)identifier;
 
 /// Returns local player's high scores for multiple leaderboards.
 - (NSDictionary *)highScoreForLeaderboards:(NSArray *)identifiers;

--- a/GC Manager/GameCenterManager.m
+++ b/GC Manager/GameCenterManager.m
@@ -304,10 +304,10 @@
                                 NSNumber *savedHighScore = [playerDict objectForKey:leaderboardRequest.localPlayerScore.leaderboardIdentifier];
                                 
                                 if (savedHighScore != nil) {
-                                    savedHighScoreValue = [savedHighScore intValue];
+                                    savedHighScoreValue = [savedHighScore longLongValue];
                                 }
                                 
-                                [playerDict setObject:[NSNumber numberWithInt:MAX(leaderboardRequest.localPlayerScore.value, savedHighScoreValue)] forKey:leaderboardRequest.localPlayerScore.leaderboardIdentifier];
+                                [playerDict setObject:[NSNumber numberWithLongLong:MAX(leaderboardRequest.localPlayerScore.value, savedHighScoreValue)] forKey:leaderboardRequest.localPlayerScore.leaderboardIdentifier];
                                 [plistDict setObject:playerDict forKey:[self localPlayerId]];
                                 NSData *saveData;
                                 if (self.shouldCryptData == YES) saveData = [[NSKeyedArchiver archivedDataWithRootObject:plistDict] encryptedWithKey:self.cryptKeyData];
@@ -425,10 +425,10 @@
                             NSNumber *savedHighScore = [playerDict objectForKey:leaderboardRequest.localPlayerScore.category];
                             
                             if (savedHighScore != nil) {
-                                savedHighScoreValue = [savedHighScore intValue];
+                                savedHighScoreValue = [savedHighScore longLongValue];
                             }
                             
-                            [playerDict setObject:[NSNumber numberWithInt:MAX(leaderboardRequest.localPlayerScore.value, savedHighScoreValue)] forKey:leaderboardRequest.localPlayerScore.category];
+                            [playerDict setObject:[NSNumber numberWithLongLong:MAX(leaderboardRequest.localPlayerScore.value, savedHighScoreValue)] forKey:leaderboardRequest.localPlayerScore.category];
                             [plistDict setObject:playerDict forKey:[self localPlayerId]];
                             
                             NSData *saveData;
@@ -586,7 +586,7 @@
 //------------------------------------------------------------------------------------------------------------//
 #pragma mark - Score and Achievement Reporting
 
-- (void)saveAndReportScore:(int)score leaderboard:(NSString *)identifier sortOrder:(GameCenterSortOrder)order  {
+- (void)saveAndReportScore:(long long)score leaderboard:(NSString *)identifier sortOrder:(GameCenterSortOrder)order  {
     NSData *gameCenterManagerData;
     if (self.shouldCryptData == YES) gameCenterManagerData = [[NSData dataWithContentsOfFile:kGameCenterManagerDataPath] decryptedWithKey:self.cryptKeyData];
     else gameCenterManagerData = [NSData dataWithContentsOfFile:kGameCenterManagerDataPath];
@@ -596,9 +596,9 @@
     if (playerDict == nil) playerDict = [NSMutableDictionary dictionary];
     
     NSNumber *savedHighScore = [playerDict objectForKey:identifier];
-    if (savedHighScore == nil) savedHighScore = [NSNumber numberWithInt:0];
+    if (savedHighScore == nil) savedHighScore = [NSNumber numberWithLongLong:0];
     
-    int savedHighScoreValue = [savedHighScore intValue];
+    long long savedHighScoreValue = [savedHighScore longLongValue];
     
     // Determine if the new score is better than the old score
     BOOL isScoreBetter = NO;
@@ -613,7 +613,7 @@
     }
     
     if (isScoreBetter) {
-        [playerDict setObject:[NSNumber numberWithInt:score] forKey:identifier];
+        [playerDict setObject:[NSNumber numberWithLongLong:score] forKey:identifier];
         [plistDict setObject:playerDict forKey:[self localPlayerId]];
         NSData *saveData;
         if (self.shouldCryptData == YES) saveData = [[NSKeyedArchiver archivedDataWithRootObject:plistDict] encryptedWithKey:self.cryptKeyData];
@@ -816,7 +816,7 @@
 //------------------------------------------------------------------------------------------------------------//
 #pragma mark - Score, Achievement, and Challenge Retrieval
 
-- (int)highScoreForLeaderboard:(NSString *)identifier {
+- (long long)highScoreForLeaderboard:(NSString *)identifier {
     NSData *gameCenterManagerData;
     if (self.shouldCryptData == YES) gameCenterManagerData = [[NSData dataWithContentsOfFile:kGameCenterManagerDataPath] decryptedWithKey:self.cryptKeyData];
     else gameCenterManagerData = [NSData dataWithContentsOfFile:kGameCenterManagerDataPath];
@@ -826,7 +826,7 @@
     if (playerDict != nil) {
         NSNumber *savedHighScore = [playerDict objectForKey:identifier];
         if (savedHighScore != nil) {
-            return [savedHighScore intValue];
+            return [savedHighScore longLongValue];
         } else {
             return 0;
         }
@@ -848,12 +848,12 @@
             NSNumber *savedHighScore = [playerDict objectForKey:identifier];
             
             if (savedHighScore != nil) {
-                [highScores setObject:[NSNumber numberWithInt:[savedHighScore intValue]] forKey:identifier];
+                [highScores setObject:[NSNumber numberWithLongLong:[savedHighScore longLongValue]] forKey:identifier];
                 continue;
             }
         }
         
-        [highScores setObject:[NSNumber numberWithInt:0] forKey:identifier];
+        [highScores setObject:[NSNumber numberWithLongLong:0] forKey:identifier];
     }
     
     NSDictionary *highScoreDict = [NSDictionary dictionaryWithDictionary:highScores];

--- a/GameCenterManager.xcodeproj/project.pbxproj
+++ b/GameCenterManager.xcodeproj/project.pbxproj
@@ -327,9 +327,6 @@
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "NABZ Software";
 				TargetAttributes = {
-					659699D51515718800724EBE = {
-						DevelopmentTeam = 243F4RK8Z3;
-					};
 					994E293F17838BF300EAACD2 = {
 						DevelopmentTeam = 243F4RK8Z3;
 						SystemCapabilities = {

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ You can get high scores from multiple leaderboards or just one leaderboard. In b
 
 To get the high score for the current player for a single leaderboard:
 
-    // Returns an integer value as a high scores
-    int highScore = [[GameCenterManager sharedManager] highScoreForLeaderboard:@"LeaderboardID"];  
+    // Returns an integer value (long long integer) as a high scores
+   long long highScore = [[GameCenterManager sharedManager] highScoreForLeaderboard:@"LeaderboardID"];  
 
 ###Get Achievement Progress
 You can get achievement progress for multiple achievements or just one achievement. In both cases you'll need to provide Achievement IDs. GameCenterManager will return either an NSDictionary with double values, or one double value. To get the achievement progress for the current player from multiple achievements:


### PR DESCRIPTION
Issues caused by the datatype of int for the highscores are fixed with this PR by increasing the max data set to long long integer.

Originally reported by #42 

This PR changes all integers (int) to long long (integers). 

**int** integer maximum sizes: ```[−2147483647,+2147483647] ```
**long long** integer maximum: ```[−9223372036854775807,+9223372036854775807]```