### PR TITLE
OSX AppSandbox Entitlement to fix "The connection to service named com.apple.gamed.osx was invalidated."

### DIFF
--- a/GC Manager/GameCenterManager.h
+++ b/GC Manager/GameCenterManager.h
@@ -16,9 +16,15 @@
     #endif
 #endif
 
-#define LIBRARY_FOLDER [NSHomeDirectory() stringByAppendingPathComponent:@"Library"]
-#define kGameCenterManagerDataFile @"GameCenterManager.plist"
-#define kGameCenterManagerDataPath [LIBRARY_FOLDER stringByAppendingPathComponent:kGameCenterManagerDataFile]
+#if TARGET_OS_IPHONE
+    #define kApplicationAppSupportDirectory [NSHomeDirectory() stringByAppendingPathComponent:@"Library"]
+    #define kGameCenterManagerDataFile @"GameCenterManager.plist"
+    #define kGameCenterManagerDataPath [kApplicationAppSupportDirectory stringByAppendingPathComponent:kGameCenterManagerDataFile]
+#else
+    #define kApplicationAppSupportDirectory [[NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) lastObject] stringByAppendingPathComponent:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"]]
+    #define kGameCenterManagerDataFile @"GameCenterManager.plist"
+    #define kGameCenterManagerDataPath [kApplicationAppSupportDirectory stringByAppendingPathComponent:kGameCenterManagerDataFile]
+#endif
 
 #import <Foundation/Foundation.h>
 #import <GameKit/GameKit.h>

--- a/GC Manager/GameCenterManager.m
+++ b/GC Manager/GameCenterManager.m
@@ -87,6 +87,12 @@
         [self setShouldCryptData:NO];
         
         NSFileManager *fileManager = [NSFileManager defaultManager];
+        if(![fileManager fileExistsAtPath:kApplicationAppSupportDirectory]) {
+            NSError *error = nil;
+            BOOL isDirectoryCreated = [fileManager createDirectoryAtPath:kApplicationAppSupportDirectory withIntermediateDirectories:NO attributes:nil error:&error];
+            if(!isDirectoryCreated) NSLog(@"Failed to created Application Support Folder: %@", error);
+        }
+        
         if (![fileManager fileExistsAtPath:kGameCenterManagerDataPath]) {
             NSMutableDictionary *dict = [NSMutableDictionary dictionary];
             NSData *saveData = [NSKeyedArchiver archivedDataWithRootObject:dict];
@@ -111,6 +117,12 @@
         self.cryptKeyData = [cryptionKey dataUsingEncoding:NSUTF8StringEncoding];
         
         NSFileManager *fileManager = [NSFileManager defaultManager];
+        if(![fileManager fileExistsAtPath:kApplicationAppSupportDirectory]) {
+            NSError *error = nil;
+            BOOL isDirectoryCreated = [fileManager createDirectoryAtPath:kApplicationAppSupportDirectory withIntermediateDirectories:NO attributes:nil error:&error];
+            if(!isDirectoryCreated) NSLog(@"Failed to created Application Support Folder: %@", error);
+        }
+        
         if (![fileManager fileExistsAtPath:kGameCenterManagerDataPath]) {
             NSMutableDictionary *dict = [NSMutableDictionary dictionary];
             NSData *saveData = [[NSKeyedArchiver archivedDataWithRootObject:dict] encryptedWithKey:self.cryptKeyData];
@@ -550,6 +562,15 @@
                     });
                 }
             }];
+        } else if( [[NSUserDefaults standardUserDefaults] boolForKey:[@"achievementsSynced" stringByAppendingString:[self localPlayerId]]] == YES &&
+                 [[NSUserDefaults standardUserDefaults] boolForKey:[@"scoresSynced" stringByAppendingString:[self localPlayerId]]] == YES ) {
+            // Game Center Synced
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if ([[self delegate] respondsToSelector:@selector(gameCenterManager:gameCenterSynced:)]) {
+                    [[self delegate] gameCenterManager:self gameCenterSynced:YES];
+                }
+            });
+        } else {
         }
     } else {
         NSError *error = [NSError errorWithDomain:[NSString stringWithFormat:@"GameCenter unavailable."] code:GCMErrorNotAvailable userInfo:nil];

--- a/GC Manager/GameCenterManager.m
+++ b/GC Manager/GameCenterManager.m
@@ -53,17 +53,36 @@
     if (self) {
         BOOL gameCenterAvailable = [self checkGameCenterAvailability:YES];
         
+        NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
+        [prefs synchronize];
+        
+        if([prefs objectForKey:@"scoresSynced"] == nil) {
+            NSLog(@"scoresSynced not setup");
+            [prefs setBool:NO forKey:[@"scoresSynced" stringByAppendingString:[self localPlayerId]]];
+        } else {
+            NSLog(@"scoresSynced WAS setup");
+        }
+        
+        if([prefs objectForKey:@"achievementsSynced"] == nil) {
+            NSLog(@"achievementsSynced not setup");
+             [prefs setBool:NO forKey:[@"achievementsSynced" stringByAppendingString:[self localPlayerId]]];
+        } else {
+            NSLog(@"achievementsSynced WAS setup");
+        }
+        [prefs synchronize];
+        
         if (gameCenterAvailable) {
             // Set GameCenter as available
             [self setIsGameCenterAvailable:YES];
-            
+
             if (![[NSUserDefaults standardUserDefaults] boolForKey:[@"scoresSynced" stringByAppendingString:[self localPlayerId]]]
                 || ![[NSUserDefaults standardUserDefaults] boolForKey:[@"achievementsSynced" stringByAppendingString:[self localPlayerId]]])
                 [self syncGameCenter];
             else
                 [self reportSavedScoresAndAchievements];
-        } else
+        } else {
             [self setIsGameCenterAvailable:NO];
+        }
     }
     
     return self;
@@ -251,7 +270,10 @@
                     [self setPreviousGameCenterAvailability:GameCenterAvailabilityPlayerAuthenticated];
                     // The current player is logged into GameCenter
                     NSDictionary *successDictionary = [NSDictionary dictionaryWithObject:@"GameCenter Available" forKey:@"status"];
-                    
+                    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+                    [userDefaults setBool:NO forKey:[@"scoresSynced" stringByAppendingString:[self localPlayerId]]];
+                    [userDefaults setBool:NO forKey:[@"achievementsSynced" stringByAppendingString:[self localPlayerId]]];
+                    [userDefaults synchronize];
                     dispatch_async(dispatch_get_main_queue(), ^{
                         if ([[self delegate] respondsToSelector:@selector(gameCenterManager:availabilityChanged:)])
                             [[self delegate] gameCenterManager:self availabilityChanged:successDictionary];
@@ -454,6 +476,7 @@
                         GCMLeaderboards = [[NSMutableArray alloc] initWithArray:leaderboards];
                         [self syncGameCenter];
                     } else {
+                        NSLog(@"%@",[error localizedDescription]);
                         dispatch_async(dispatch_get_main_queue(), ^{
                             if ([[self delegate] respondsToSelector:@selector(gameCenterManager:error:)])
                                 [[self delegate] gameCenterManager:self error:error];
@@ -517,6 +540,7 @@
                         [self syncGameCenter];
                     } else {
                         dispatch_async(dispatch_get_main_queue(), ^{
+                            NSLog(@"%@",[error localizedDescription]);
                             if ([[self delegate] respondsToSelector:@selector(gameCenterManager:error:)])
                                 [[self delegate] gameCenterManager:self error:error];
                         });
@@ -556,6 +580,7 @@
                     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:[@"achievementsSynced" stringByAppendingString:[self localPlayerId]]];
                     [self syncGameCenter];
                 } else {
+                    NSLog(@"%@",[error localizedDescription]);
                     dispatch_async(dispatch_get_main_queue(), ^{
                         if ([[self delegate] respondsToSelector:@selector(gameCenterManager:error:)])
                             [[self delegate] gameCenterManager:self error:error];

--- a/GameCenterManager Mac/GameCenterManager Mac-Info.plist
+++ b/GameCenterManager Mac/GameCenterManager Mac-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.iRare-Media.GameCenterManager.Mac</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/GameCenterManager Mac/GameCenterManager Mac.entitlements
+++ b/GameCenterManager Mac/GameCenterManager Mac.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.game-center</key>
+	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/GameCenterManager.xcodeproj/project.pbxproj
+++ b/GameCenterManager.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -527,8 +527,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GameCenterManager/GameCenterManager-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
@@ -536,8 +534,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
 			};
@@ -549,16 +545,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "GameCenterManager/GameCenterManager-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				INFOPLIST_FILE = "GameCenterManager/GameCenterManager-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
 			};
@@ -572,10 +564,6 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
-				CODE_SIGN_ENTITLEMENTS = "GameCenterManager Mac/GameCenterManager Mac.entitlements";
-				CODE_SIGN_IDENTITY = "Mac Developer: iRare Media (4N75L7CCKZ)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Mac Developer: iRare Media (4N75L7CCKZ)";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer: iRare Media (4N75L7CCKZ)";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -588,9 +576,8 @@
 				INFOPLIST_FILE = "GameCenterManager Mac/GameCenterManager Mac-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gamecentermanager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "44e2c126-8374-4773-bac4-eb76cae11b1f";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "44e2c126-8374-4773-bac4-eb76cae11b1f";
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = app;
 			};
@@ -604,10 +591,6 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
-				CODE_SIGN_ENTITLEMENTS = "GameCenterManager Mac/GameCenterManager Mac.entitlements";
-				CODE_SIGN_IDENTITY = "Mac Developer: iRare Media (4N75L7CCKZ)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Mac Developer: iRare Media (4N75L7CCKZ)";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer: iRare Media (4N75L7CCKZ)";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -620,9 +603,8 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				INFOPLIST_FILE = "GameCenterManager Mac/GameCenterManager Mac-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gamecentermanager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "44e2c126-8374-4773-bac4-eb76cae11b1f";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "44e2c126-8374-4773-bac4-eb76cae11b1f";
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = app;
 			};

--- a/GameCenterManager.xcodeproj/project.pbxproj
+++ b/GameCenterManager.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
+				CODE_SIGN_ENTITLEMENTS = "GameCenterManager Mac/GameCenterManager Mac.entitlements";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -591,6 +592,7 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
+				CODE_SIGN_ENTITLEMENTS = "GameCenterManager Mac/GameCenterManager Mac.entitlements";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (


### PR DESCRIPTION
Fixes: https://github.com/nihalahmed/GameCenterManager/issues/32

> Could not get services from gamed. 
Please file a radar including GameKit logs, and any gamed crash logs. 
ERROR Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.gamed.osx was invalidated." 
UserInfo={NSDebugDescription=The connection to service named com.apple.gamed.osx was invalidated.}

When in AppSandbox mode on OSX (AppStore submission).

I've also posed a radar for this, as it is not documented or referenced or generated anywhere by default.
radar: rdar://23594124

It was absolute hell tracking this one down.