### PR TITLE
Fix - / Revert Modules change 

### DIFF
--- a/GC Manager/GCMMultiplayer.h
+++ b/GC Manager/GCMMultiplayer.h
@@ -6,8 +6,8 @@
 //  Copyright © 2015 NABZ Software. All rights reserved.
 //
 
-@import Foundation;
-@import GameKit;
+#import <Foundation/Foundation.h>
+#import <GameKit/GameKit.h>
 
 #import "GCMConstants.h"
 

--- a/GC Manager/GameCenterManager.h
+++ b/GC Manager/GameCenterManager.h
@@ -27,13 +27,13 @@
 #endif
 
 
-@import Foundation;
-@import GameKit;
+#import <Foundation/Foundation.h>
+#import <GameKit/GameKit.h>
 
 #if TARGET_OS_IPHONE
-    @import UIKit;
+    #import <UIKit/UIKit.h>
 #else
-    @import Cocoa;
+    #import <Cocoa/Cocoa.h>
 #endif
 
 #import "Reachability.h"

--- a/GameCenterManager.xcodeproj/project.pbxproj
+++ b/GameCenterManager.xcodeproj/project.pbxproj
@@ -573,7 +573,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = MacAppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CODE_SIGN_ENTITLEMENTS = "GameCenterManager Mac/GameCenterManager Mac.entitlements";
@@ -602,7 +601,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = MacAppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CODE_SIGN_ENTITLEMENTS = "GameCenterManager Mac/GameCenterManager Mac.entitlements";


### PR DESCRIPTION
Fixes https://github.com/nihalahmed/GameCenterManager/issues/65
- Reverts the project change to use Modules.
- Modules are not supported by Objective-C++
