### PR TITLE
Fix for GCMMultiplayer for OS X

### DIFF
--- a/GC Manager/GCMMultiplayer.h
+++ b/GC Manager/GCMMultiplayer.h
@@ -74,7 +74,12 @@
 /// @b Readonly. Indicates whether or not the multiplayer match has started (if one has been created).
 @property (nonatomic, assign, readonly) BOOL multiplayerMatchStarted;
 
+#if TARGET_OS_IPHONE
 @property (nonatomic, strong, readonly) UIViewController *matchPresentingController;
+#else
+@property (nonatomic, strong, readonly) NSViewController *matchPresentingController;
+#endif
+
 
 @end
 


### PR DESCRIPTION
Fix for GCMMultiplayer for OS X
- Pre-Processor for UIViewController to NSViewController.
