### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+
+language: objective-c
+compiler: clang
+osx_image: xcode7.2
+sudo: truev
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+      env: TARGET="osx"
+    - os: osx
+      compiler: clang
+      env: TARGET="ios"
+script:
+    - travis/$TARGET/build.sh
+git:
+    depth: 10

--- a/travis/ios/build.sh
+++ b/travis/ios/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ev
+echo "**** Building - iOS GameCenterManager Example Project ****"
+ROOT=${TRAVIS_BUILD_DIR:-"$( cd "$(dirname "$0")/../.." ; pwd -P )"}
+xcodebuild -project "$ROOT/GameCenterManager.xcodeproj"  -target GameCenterManager -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
+

--- a/travis/osx/build.sh
+++ b/travis/osx/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ev
+ROOT=${TRAVIS_BUILD_DIR:-"$( cd "$(dirname "$0")/../.." ; pwd -P )"}
+echo "**** Building - OSX GameCenterManager Example Project ****"
+xcodebuild -configuration Release -target "GameCenterManager Mac" -project "$ROOT/GameCenterManager.xcodeproj"
+


### PR DESCRIPTION
### Adding Travis CI 

- Automatically tests commits / PR's
- Builds the Xcode Example project on different matrix machines. Currently testing:
  - OS X
  - iOS

I've currently tested on my fork here:
https://travis-ci.org/danoli3/GameCenterManager/branches

@Sam-Spencer to add to the main repo you will have to login to Travis-ci here:
https://travis-ci.org
Then click the green button to turn it on for nihalahmed/GameCenterManager. After that any future PR's or commits will be automatically tested with their results shown in github. (those after this PR is merged, you have to have the .travis.yml present)

